### PR TITLE
netboot fix bootp -> tftpboot

### DIFF
--- a/include/configs/lsxl.h
+++ b/include/configs/lsxl.h
@@ -8,6 +8,8 @@
 #ifndef _CONFIG_LSXL_H
 #define _CONFIG_LSXL_H
 
+#define CONFIG_SYS_GENERIC_BOARD
+
 /*
  * Version number information
  */
@@ -157,7 +159,7 @@
 	"standard_env=setenv ipaddr; setenv netmask; setenv serverip; "	\
 		"setenv ncip; setenv gatewayip; setenv ethact; "	\
 		"setenv bootfile; setenv dnsip; "			\
-		"setenv bootsource hdd; run ser\0"			\
+		"setenv bootsource legacy; run ser\0"			\
 	"restore_env=run standard_env; saveenv; reset\0"		\
 	"ser=setenv stdin serial; setenv stdout serial; "		\
 		"setenv stderr serial\0"				\

--- a/include/configs/lsxl.h
+++ b/include/configs/lsxl.h
@@ -130,7 +130,7 @@
 		"&& load ide ${hdpart} 0x00100000 /uImage.buffalo "	\
 		"&& load ide ${hdpart} 0x00800000 /initrd.buffalo "	\
 		"&& bootm 0x00100000 0x00800000\0"			\
-	"bootcmd_net=bootp ${kernel_addr} uImage "			\
+	"bootcmd_net=tftpboot ${kernel_addr} uImage "			\
 		"&& tftpboot ${ramdisk_addr} uInitrd "			\
 		"&& tftpboot ${fdt_addr} " CONFIG_FDTFILE " "		\
 		"&& bootm ${kernel_addr} ${ramdisk_addr} ${fdt_addr}\0"	\


### PR DESCRIPTION
My machine requires that the netboot command be tftpboot, not bootp.  Is that abnormal?